### PR TITLE
Added support for setting parameters via command-line arguments, and …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/*

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"start": "node tweetstorss.js"
 			},
 	"dependencies" : {
-		"node-twitter-api": "*"
+		"node-twitter-api": "*",
+		"nconf": "*"
 		}, 
 	"license": "MIT",
 	"engines": {

--- a/tweetstorss.js
+++ b/tweetstorss.js
@@ -25,12 +25,20 @@ var myVersion = "0.45", myProductName = "tweetsToRss", myProductUrl = "https://g
 var fs = require ("fs");
 var twitterAPI = require ("node-twitter-api");
 
-var twitterConsumerKey = process.env.twitterConsumerKey;
-var twitterConsumerSecret = process.env.twitterConsumerSecret;
-var accessToken = process.env.twitterAccessToken;
-var accessTokenSecret = process.env.twitterAccessTokenSecret;
-var twitterScreenName = process.env.twitterScreenName;
-var pathRssFile = process.env.pathRssFile;
+// Use nconf to be able to read settings command-line if required
+var nconf = require('nconf');
+nconf.argv().env();
+
+// Fetch data every minute by default, but you can turn this off and fetch the data just once (e.g. via a cron script) by setting --runEveryMinute false on the command line
+nconf.defaults({'runEveryMinute': true});
+
+var twitterConsumerKey = nconf.get('twitterConsumerKey');
+var twitterConsumerSecret = nconf.get('twitterConsumerSecret');
+var accessToken = nconf.get('accessToken');
+var accessTokenSecret = nconf.get('accessTokenSecret');
+var twitterScreenName = nconf.get('twitterScreenName');
+var pathRssFile = nconf.get('pathRssFile');
+var runEveryMinute = nconf.get('runEveryMinute');
 
 var defaultRssFilePath = "rss.xml";
 var flSkipReplies = true;
@@ -501,7 +509,10 @@ function startup () {
 			}
 	
 	everyMinute (); //call once at startup, then every minute
-	setInterval (everyMinute, 60000); 
+	
+	if (runEveryMinute === true) {
+		setInterval (everyMinute, 60000); 
 	}
+}
 startup ();
 


### PR DESCRIPTION
…for running once only

I made this change because on my shared host server I can only run cron jobs, so I didn't want it to run continuously.

Basically using the nconf library means you can use either environment variables or command-line arguments to the script to set the various parameters.

I also added a "runEveryMinute" parameter - defaulting to true to keep original behaviour - that can be set to false which will run the code only once and then exit the script.

Your script saved me a lot of time, so am happy to contribute my minor changes if you think other people may find them useful (and definitely feel free to ignore them if you don't!)

Thanks
John Pollard
